### PR TITLE
Kill dotted view syntax for url reversing

### DIFF
--- a/app/hyperbola/contact/models.py
+++ b/app/hyperbola/contact/models.py
@@ -68,7 +68,7 @@ class Resume(models.Model):
     resume = models.FileField(upload_to="resume/%Y/%m/%d/%H-%M/lopopolo.pdf")
 
     def get_absolute_url(self):
-        return reverse("resume-pdf")
+        return reverse("contact-resume-pdf")
 
     def display_name(self):
         return "As of {0}".format(self.date.strftime("%b %d %Y"))

--- a/app/hyperbola/contact/urls.py
+++ b/app/hyperbola/contact/urls.py
@@ -4,8 +4,8 @@ from django.views.generic import RedirectView
 from hyperbola.contact import views
 
 urlpatterns = [
-    url(r'^$', views.index),
-    url(r'^resume/lopopolo.pdf$', views.resume, name="resume-pdf"),
-    url(r'^resume/?$', RedirectView.as_view(pattern_name="resume-pdf",
+    url(r'^$', views.index, name="contact-index"),
+    url(r'^resume/lopopolo.pdf$', views.resume, name="contact-resume-pdf"),
+    url(r'^resume/?$', RedirectView.as_view(pattern_name="contact-resume-pdf",
                                             permanent=True)),
 ]

--- a/app/hyperbola/frontpage/urls.py
+++ b/app/hyperbola/frontpage/urls.py
@@ -3,5 +3,5 @@ from django.conf.urls import url
 from hyperbola.frontpage import views
 
 urlpatterns = [
-    url(r'^$', views.index),
+    url(r'^$', views.index, name="frontpage-index"),
 ]

--- a/app/hyperbola/lifestream/syndication.py
+++ b/app/hyperbola/lifestream/syndication.py
@@ -17,7 +17,7 @@ class LatestEntriesFeed(Feed):
     description_template = "blurb_feed.html"
 
     def link(self):
-        return reverse(views.lifestream_index)
+        return reverse(views.index)
 
     def feed_url(self):
         return reverse("lifestream-rss")

--- a/app/hyperbola/lifestream/templates/lifestream_404.html
+++ b/app/hyperbola/lifestream/templates/lifestream_404.html
@@ -11,7 +11,7 @@ hyperbo.la :: lifestream
   <div class="col-md-8">
     <h2>No lifestream posts were found</h2>
     <div>
-      <a href="{% url "lifestream-home"  %}">Return to lifestream home.</a>
+      <a href="{% url "lifestream-index" %}">Return to lifestream home.</a>
     </div>
   </div>
   <div class="col-md-4">
@@ -20,7 +20,7 @@ hyperbo.la :: lifestream
       <li class="feed-icon"><a href="{% url "lifestream-rss" %}">RSS</a></li>
       <li class="feed-icon"><a href="{% url "lifestream-atom" %}">Atom</a></li>
     </ul>
-    {% for d in dates  %}
+    {% for d in dates %}
     {% ifchanged d.month.year %}
     {% if not forloop.first %}
     </ul>
@@ -31,7 +31,7 @@ hyperbo.la :: lifestream
     <ul class="list-unstyled">
     {% endifchanged %}
     {% ifchanged d.month.year d.month.month %}
-    <li><a href="{% url "lifestream.views.archive_index" d.month|date:"Y" d.month|date:"m" %}">{{d.month|date:"F"}}</a> <span class="badge pull-right">{{d.post_count|escape}}</span></li>
+    <li><a href="{% url "lifestream-archive" d.month|date:"Y" d.month|date:"m" %}">{{d.month|date:"F"}}</a> <span class="badge pull-right">{{d.post_count|escape}}</span></li>
     {% endifchanged %}
     {% if forloop.last %}
     </ul>

--- a/app/hyperbola/lifestream/templates/lifestream_archived_posts.html
+++ b/app/hyperbola/lifestream/templates/lifestream_archived_posts.html
@@ -4,10 +4,10 @@
 
 {% block lifestream-page-links %}
 {% if posts.has_previous %}
-{% url "lifestream.views.archive_index" month|date:"Y" month|date:"m" posts.previous_page_number as newer  %}
+{% url "lifestream-archive-paged" month|date:"Y" month|date:"m" posts.previous_page_number as newer  %}
 {% endif %}
 {% if posts.has_next %}
-{% url "lifestream.views.archive_index" month|date:"Y" month|date:"m" posts.next_page_number as older %}
+{% url "lifestream-archive-paged" month|date:"Y" month|date:"m" posts.next_page_number as older %}
 {% endif %}
 {% include "page_links.html" %}
 {% endblock %}

--- a/app/hyperbola/lifestream/templates/lifestream_base_paged.html
+++ b/app/hyperbola/lifestream/templates/lifestream_base_paged.html
@@ -20,7 +20,7 @@ hyperbo.la :: lifestream{% if posts.number != 1 %} :: page {{posts.number|string
           {{post.pub_date|date:"H:i T b d Y"|lower}}
         </noscript>
       </span>
-      <a href="{% url "lifestream.views.permalink" post.pk  %}">permalink</a>
+      <a href="{% url "lifestream-entry-permalink" post.pk %}">permalink</a>
       </div>
       <div class="panel-body">
       {% if post.lifestreampicture %}
@@ -58,7 +58,7 @@ hyperbo.la :: lifestream{% if posts.number != 1 %} :: page {{posts.number|string
       <li class="feed-icon"><a href="{% url "lifestream-rss" %}">RSS</a></li>
       <li class="feed-icon"><a href="{% url "lifestream-atom" %}">Atom</a></li>
     </ul>
-    {% for d in dates  %}
+    {% for d in dates %}
     {% ifchanged d.month.year %}
     {% if not forloop.first %}
     </ul>
@@ -69,7 +69,7 @@ hyperbo.la :: lifestream{% if posts.number != 1 %} :: page {{posts.number|string
     <ul class="list-unstyled">
     {% endifchanged %}
     {% ifchanged d.month.year d.month.month %}
-    <li><a href="{% url "lifestream.views.archive_index" d.month|date:"Y" d.month|date:"m" %}">{{d.month|date:"F"}}</a> <span class="badge pull-right">{{d.post_count|escape}}</span></li>
+    <li><a href="{% url "lifestream-archive" d.month|date:"Y" d.month|date:"m" %}">{{d.month|date:"F"}}</a> <span class="badge pull-right">{{d.post_count|escape}}</span></li>
     {% endifchanged %}
     {% if forloop.last %}
     </ul>

--- a/app/hyperbola/lifestream/templates/lifestream_paged.html
+++ b/app/hyperbola/lifestream/templates/lifestream_paged.html
@@ -2,10 +2,10 @@
 
 {% block lifestream-page-links %}
 {% if posts.has_previous %}
-{% url "lifestream-index" page=posts.previous_page_number as newer %}
+{% url "lifestream-index-paged" page=posts.previous_page_number as newer %}
 {% endif %}
 {% if posts.has_next %}
-{% url "lifestream-index" page=posts.next_page_number as older %}
+{% url "lifestream-index-paged" page=posts.next_page_number as older %}
 {% endif %}
 {% include "page_links.html" %}
 {% endblock %}

--- a/app/hyperbola/lifestream/templates/lifestream_paged.html
+++ b/app/hyperbola/lifestream/templates/lifestream_paged.html
@@ -2,10 +2,10 @@
 
 {% block lifestream-page-links %}
 {% if posts.has_previous %}
-{% url "lifestream.views.lifestream_index" posts.previous_page_number as newer  %}
+{% url "lifestream-index" page=posts.previous_page_number as newer %}
 {% endif %}
 {% if posts.has_next %}
-{% url "lifestream.views.lifestream_index" posts.next_page_number as older  %}
+{% url "lifestream-index" page=posts.next_page_number as older %}
 {% endif %}
 {% include "page_links.html" %}
 {% endblock %}

--- a/app/hyperbola/lifestream/templates/lifestream_tag_paged.html
+++ b/app/hyperbola/lifestream/templates/lifestream_tag_paged.html
@@ -4,10 +4,10 @@
 
 {% block lifestream-page-links %}
 {% if posts.has_previous %}
-{% url "lifestream.views.hashtag_index" page=posts.previous_page_number tag=tag as newer %}
+{% url "lifestream-hashtag-paged" page=posts.previous_page_number tag=tag as newer %}
 {% endif %}
 {% if posts.has_next %}
-{% url "lifestream.views.hashtag_index" page=posts.next_page_number tag=tag as older %}
+{% url "lifestream-hashtag-paged" page=posts.next_page_number tag=tag as older %}
 {% endif %}
 {% include "page_links.html" %}
 {% endblock %}

--- a/app/hyperbola/lifestream/templatetags/hashtagize.py
+++ b/app/hyperbola/lifestream/templatetags/hashtagize.py
@@ -6,7 +6,7 @@ from django.template.defaultfilters import stringfilter
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 
-from hyperbola.lifestream.views import hashtag_index
+from hyperbola.lifestream.views import hashtag
 
 
 register = template.Library()
@@ -29,7 +29,7 @@ def hashtagize(blurb, autoescape=True):
 
     def linkify(matchobj):
         tag = matchobj.group('tag')
-        url = reverse(hashtag_index, args=[tag])
+        url = reverse(hashtag, args=[tag])
         if 'leader' in matchobj.groupdict():
             leader = matchobj.group('leader')
         else:

--- a/app/hyperbola/lifestream/urls.py
+++ b/app/hyperbola/lifestream/urls.py
@@ -6,16 +6,18 @@ from hyperbola.lifestream.syndication import (
 
 
 urlpatterns = [
-    url(r'^$', views.lifestream_index, name='lifestream-home'),
-    url(r'^page/(?P<page>[1-9]\d*)/$', views.lifestream_index),
-    url(r'^archive/(?P<year>\d{4})/(?P<month>\d{2})/$', views.archive_index),
+    url(r'^$', views.index, name='lifestream-index'),
+    url(r'^page/(?P<page>[1-9]\d*)/$', views.index,
+        name='lifestream-index-paged'),
+    url(r'^archive/(?P<year>\d{4})/(?P<month>\d{2})/$', views.archive,
+        name='lifestream-archive'),
     url(r'^archive/(?P<year>\d{4})/(?P<month>\d{2})/page/(?P<page>[1-9]\d*)/$',
-        views.archive_index),
-    url(r'^hashtag/(?P<tag>\w+)/$', views.hashtag_index),
+        views.archive, name='lifestream-archive-paged'),
+    url(r'^hashtag/(?P<tag>\w+)/$', views.hashtag, name='lifestream-hashtag'),
     url(r'^hashtag/(?P<tag>\w+)/page/(?P<page>[1-9]\d*)/$',
-        views.hashtag_index),
+        views.hashtag, name='lifestream-hashtag-paged'),
     url(r'^(?P<entry_id>\d+)/$', views.permalink,
-        name="lifestream-entry-permalink"),
+        name='lifestream-entry-permalink'),
 ]
 
 urlpatterns += [

--- a/app/hyperbola/lifestream/views.py
+++ b/app/hyperbola/lifestream/views.py
@@ -44,7 +44,7 @@ def get_archive_range():
 
 
 @handle_lifestream_404
-def lifestream_index(request, page=1):
+def index(request, page=1):
     posts = LifeStreamItem.objects.all().select_related('lifestreampicture')
     if not posts.exists():
         raise Http404
@@ -57,7 +57,7 @@ def lifestream_index(request, page=1):
 
 
 @handle_lifestream_404
-def archive_index(request, year, month, page=1):
+def archive(request, year, month, page=1):
     year = int(year)
     month = int(month)
 
@@ -77,7 +77,7 @@ def archive_index(request, year, month, page=1):
 
 
 @handle_lifestream_404
-def hashtag_index(request, tag, page=1):
+def hashtag(request, tag, page=1):
     hashedtag = r"#{0}([^A-Za-z0-9]|$)".format(tag)
     qs = LifeStreamItem.objects.filter(blurb__iregex=hashedtag) \
         .select_related('lifestreampicture')

--- a/app/hyperbola/templates/404.html
+++ b/app/hyperbola/templates/404.html
@@ -9,6 +9,6 @@
     <h1>Page Not Found</h1>
     <br>
     <p>This isn't the page you're looking for.</p>
-    <a href="{% url "frontpage.views.index" %}" class="btn btn-large hyperbola-btn-info"><span class="glyphicon glyphicon-home"></span> Home</a>
+    <a href="{% url "frontpage-index" %}" class="btn btn-large hyperbola-btn-info"><span class="glyphicon glyphicon-home"></span> Home</a>
   </div>
 {% endblock %}

--- a/app/hyperbola/templates/base.html
+++ b/app/hyperbola/templates/base.html
@@ -26,13 +26,13 @@
             <span class="icon-bar"></span>
             <span class="icon-bar"></span>
           </button>
-          <a class="hyperbola-logo text-hide" href="{% url "frontpage.views.index" %}">Hyperbola Front Page</a>
+          <a class="hyperbola-logo text-hide" href="{% url "frontpage-index" %}">Hyperbola Front Page</a>
         </div>
         <div class="navbar-collapse collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li class="hyperbola-home text-center"><a href="{% url "frontpage.views.index" %}"><strong>home</strong></a></li>
-            <li class="hyperbola-contact text-center"><a href="{% url "contact.views.index" %}"><strong>contact</strong></a></li>
-            <li class="hyperbola-lifestream text-center"><a href="{% url "lifestream.views.lifestream_index" %}"><strong>lifestream</strong></a></li>
+            <li class="hyperbola-home text-center"><a href="{% url "frontpage-index" %}"><strong>home</strong></a></li>
+            <li class="hyperbola-contact text-center"><a href="{% url "contact-index" %}"><strong>contact</strong></a></li>
+            <li class="hyperbola-lifestream text-center"><a href="{% url "lifestream-index" %}"><strong>lifestream</strong></a></li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
Per django 1.8 docs, the 'app.views.viewname' method of url reversing
in templates with the url tag is deprecated and will be removed in
django 1.10.

This patchset creates a consistent set of names for all urls that need
to be reversed. All names are prefixed with app_name, for example,
lifestream-index.

This patchset also renames the existing lifestream view functions so
they are not prefixed with app_name. This brings them more in line with
other apps in hyperbola.

Fixes GH-31.

https://docs.djangoproject.com/en/1.8/ref/templates/builtins/#url