### PR TITLE
Refactor healthz endpoint to be implemented in middleware

### DIFF
--- a/app/hyperbola/core/middleware.py
+++ b/app/hyperbola/core/middleware.py
@@ -1,5 +1,8 @@
+import logging
 import socket
+import uuid
 
+from django.http import HttpResponse, HttpResponseServerError
 from django.utils.encoding import force_bytes
 
 _FQDN = socket.getfqdn()
@@ -22,3 +25,49 @@ class FQDNMiddleware(object):
                 pass
 
         return response
+
+
+# https://www.ianlewis.org/en/kubernetes-health-checks-django
+class HealthCheckMiddleware(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.logger = logging.getLogger('healthz')
+        self.cache_key = uuid.uuid4().hex
+
+    def __call__(self, request):
+        if request.path == '/healthz' and request.method in ['GET', 'HEAD']:
+            return self.healthz(request)
+        return self.get_response(request)
+
+    def healthz(self, request):
+        """Return that the server is healthy."""
+        # Connect to each database and do a generic standard SQL query
+        # that doesn't write any data and doesn't depend on any tables
+        # being present.
+        try:
+            from django.db import connections
+            for name in connections:
+                cursor = connections[name].cursor()
+                cursor.execute('SELECT 1;')
+                row = cursor.fetchone()
+                if row is None:
+                    return HttpResponseServerError('KO: db: invalid response')
+        except Exception as e:
+            self.logger.exception(e)
+            return HttpResponseServerError('KO: db: cannot connect to database.')
+
+        # Do a roundtrip SET and GET on a random key/value.
+        # This can effectively check if each is online.
+        try:
+            from django.core.cache import caches
+            for cache in caches.all():
+                cache_value = uuid.uuid4().hex
+                cache.set(self.cache_key, cache_value)
+                result = cache.get(self.cache_key)
+                if result != cache_value:
+                    return HttpResponseServerError('KO: cache: round trip error.')
+        except Exception as e:
+            self.logger.exception(e)
+            return HttpResponseServerError('KO: cache: cannot connect to cache.')
+
+        return HttpResponse('OK')

--- a/app/hyperbola/core/middleware.py
+++ b/app/hyperbola/core/middleware.py
@@ -5,22 +5,20 @@ import uuid
 from django.http import HttpResponse, HttpResponseServerError
 from django.utils.encoding import force_bytes
 
-_FQDN = socket.getfqdn()
-_COMMENT = force_bytes('<!-- canonical hostname: {} -->'.format(_FQDN))
-
 
 class FQDNMiddleware(object):
     """Inject the canonical hostname for the host that rendered the request."""
 
     def __init__(self, get_response):
         self.get_response = get_response
+        self.comment = force_bytes('<!-- canonical hostname: {} -->'.format(socket.getfqdn()))
 
     def __call__(self, request):
         response = self.get_response(request)
 
         if 'Content-Type' in response and 'text/html' in response['Content-Type']:
             try:
-                response.content = response.content + _COMMENT
+                response.content = response.content + self.comment
             except ValueError:
                 pass
 

--- a/app/hyperbola/core/views.py
+++ b/app/hyperbola/core/views.py
@@ -1,5 +1,3 @@
-from django.http import HttpResponse
-from django.views.generic import View
 from django.views.generic.base import TemplateView
 
 
@@ -9,25 +7,3 @@ class NotFound404View(TemplateView):
     def get(self, request, *args, **kwargs):
         context = self.get_context_data(**kwargs)
         return self.render_to_response(context, status=404)
-
-
-class HttpResponseServiceUnavailable(HttpResponse):
-    status_code = 503
-
-
-class ReadinessCheckView(View):
-    """Simple readiness check view to determine DB connection / query."""
-
-    @classmethod
-    def get(cls, request):
-        import django.db
-        del request
-        try:
-            with django.db.connection.cursor() as c:
-                c.execute("SELECT 0")
-        except django.db.Error:
-            return HttpResponseServiceUnavailable("Database health check failed")
-
-        return HttpResponse("OK", content_type="text/plain")
-
-    head = get

--- a/app/hyperbola/settings.py
+++ b/app/hyperbola/settings.py
@@ -212,6 +212,7 @@ INSTALLED_APPS = [
 ] + ENVIRONMENT.additional_installed_apps
 
 MIDDLEWARE = [
+    'hyperbola.core.middleware.HealthCheckMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/app/hyperbola/urls.py
+++ b/app/hyperbola/urls.py
@@ -18,7 +18,7 @@ from django.conf import settings
 from django.conf.urls import include, url
 
 from .contact import urls as contact
-from .core.views import NotFound404View, ReadinessCheckView
+from .core.views import NotFound404View
 from .frontpage import urls as frontpage
 from .lifestream import urls as lifestream
 
@@ -26,6 +26,5 @@ urlpatterns = [
     url(r'', include(frontpage)),
     url(r'^contact/', include(contact)),
     url(r'^lifestream/', include(lifestream)),
-    url(r'^healthz$', ReadinessCheckView.as_view()),
     url(r'^404.html$', NotFound404View.as_view()),
 ] + settings.ENVIRONMENT.additional_urls


### PR DESCRIPTION
Implement healthz as the first middleware in the chain to prevent other middleware from throwing before the view is reached.